### PR TITLE
feat: Add source record status update and CRM link navigation

### DIFF
--- a/AuditController.cs
+++ b/AuditController.cs
@@ -1,0 +1,444 @@
+﻿using Data8.PowerPlatform.Dataverse.Client;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Query;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Orchidpharmed.Medical.AdverseEventAPI.IHelper;
+using System.Collections.Concurrent;
+
+
+[Route("api/[controller]")]
+[ApiController]
+public class AuditController : ControllerBase
+{
+    private readonly Helper _helper;
+    private IOrganizationService OrgService;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AuditController> _logger;
+
+    public AuditController(IConfiguration configuration, ILogger<AuditController> logger)
+    {
+        _logger = logger;
+        _configuration = configuration;
+        var crmServiceUrl = _configuration["CRMServiceUrl"];
+        try
+        {
+            OrgService = new OnPremiseClient(crmServiceUrl,
+            _configuration["CRMUsername"],
+            _configuration["CRMPassword"]);
+            _helper = new Helper(OrgService);
+        }
+        catch (Exception e)
+        {
+            _logger.LogInformation($"Error - {DateTime.Now.ToLongTimeString()} - Error while trying to connect to CRM. Details: {e.Message}");
+        }
+    }
+
+    [HttpGet("GetOpportunityAudit")]
+    public async Task<IActionResult> GetOpportunityAudit(DateTime startDate, DateTime endDate, int pageNumber = 1)
+    {
+        try
+        {
+            var query = new QueryExpression("audit")
+            {
+                ColumnSet = new ColumnSet(true),
+                PageInfo = new PagingInfo
+                {
+                    PageNumber = pageNumber,
+                    Count = 50 // Adjust the page size as needed
+                }
+            };
+
+            // Filter by date range
+            query.Criteria.AddCondition("createdon", ConditionOperator.OnOrAfter, startDate);
+            query.Criteria.AddCondition("createdon", ConditionOperator.OnOrBefore, endDate);
+
+
+            var objectTypeCodeFilter = new FilterExpression(LogicalOperator.Or);
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "opportunity");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "new_productorder");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "new_productdonation");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "op_moratoriumtime");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "new_otherfocgift");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "new_productordertracking");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "new_opportunitycontact");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "op_opportunityletter");
+            objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, "op_attachment");
+
+            query.Criteria.AddFilter(objectTypeCodeFilter);
+
+
+
+            var results = new List<Entity>();
+            EntityCollection response;
+
+            response = OrgService.RetrieveMultiple(query);
+            results.AddRange(response.Entities);
+
+            var auditHistory = new ConcurrentBag<JObject>();
+
+            Parallel.ForEach(results, entity =>
+            {
+                try
+                {
+                    EntityReference entityRef = entity.GetAttributeValue<EntityReference>("objectid");
+                    var attributeMask = entity.GetAttributeValue<string>("attributemask");
+                    var attributeNames = DecryptAttributeMask(attributeMask, entityRef.LogicalName);
+
+                    Parallel.ForEach(attributeNames, attributeName =>
+                    {
+                        try
+                        {
+                            var history = GetAuditHistoryForField(entityRef.LogicalName, entityRef.Id, attributeName, entity.Id, true);
+                            auditHistory.Add(history);
+                        }
+                        catch (Exception)
+                        {
+                            // Log or handle the exception as needed
+                        }
+                    });
+                }
+                catch (Exception)
+                {
+                    // Log or handle the exception as needed
+                }
+            });
+
+            var result = new
+            {
+                Audit = JArray.FromObject(auditHistory),//auditHistory.Select(j => j.ToObject<object>()).ToList(),
+                PageNumber = pageNumber,
+                NextPage = response.MoreRecords
+            };
+
+            return Content(JsonConvert.SerializeObject(result), "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Error retrieving audit records: {ex.Message}");
+            return StatusCode(500, ex.Message);
+        }
+    }
+
+    [HttpGet("GetAudit")]
+    public async Task<IActionResult> GetAudit(DateTime startDate, DateTime endDate, string tableName, int pageNumber = 1)
+    {
+        try
+        {
+            var query = new QueryExpression("audit")
+            {
+                ColumnSet = new ColumnSet(true),
+                PageInfo = new PagingInfo
+                {
+                    PageNumber = pageNumber,
+                    Count = 50 // Adjust the page size as needed
+                }
+            };
+
+            // Filter by date range
+            query.Criteria.AddCondition("createdon", ConditionOperator.OnOrAfter, startDate);
+            query.Criteria.AddCondition("createdon", ConditionOperator.OnOrBefore, endDate);
+
+            // Filter by object type codes
+            if (string.IsNullOrEmpty(tableName))
+            {
+                throw new ArgumentException("Table Name can not be null");
+            }
+            else
+            {
+                var objectTypeCodeFilter = new FilterExpression(LogicalOperator.And);
+                objectTypeCodeFilter.AddCondition("objecttypecode", ConditionOperator.Equal, tableName);
+                query.Criteria.AddFilter(objectTypeCodeFilter);
+            }
+
+
+            var results = new List<Entity>();
+            EntityCollection response;
+
+            response = OrgService.RetrieveMultiple(query);
+            results.AddRange(response.Entities);
+
+            var auditHistory = new ConcurrentBag<JObject>();
+
+            Parallel.ForEach(results, entity =>
+            {
+                try
+                {
+                    EntityReference entityRef = entity.GetAttributeValue<EntityReference>("objectid");
+                    var attributeMask = entity.GetAttributeValue<string>("attributemask");
+                    var attributeNames = DecryptAttributeMask(attributeMask, entityRef.LogicalName);
+
+                    Parallel.ForEach(attributeNames, attributeName =>
+                    {
+                        try
+                        {
+                            var history = GetAuditHistoryForField(entityRef.LogicalName, entityRef.Id, attributeName, entity.Id, false);
+                            auditHistory.Add(history);
+                        }
+                        catch (Exception)
+                        {
+                            // Log or handle the exception as needed
+                        }
+                    });
+                }
+                catch (Exception)
+                {
+                    // Log or handle the exception as needed
+                }
+            });
+
+            var result = new
+            {
+                Audit = JArray.FromObject(auditHistory),//auditHistory.Select(j => j.ToObject<object>()).ToList(),
+                PageNumber = pageNumber,
+                NextPage = response.MoreRecords
+            };
+
+            return Content(JsonConvert.SerializeObject(result), "application/json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError($"Error retrieving audit records: {ex.Message}");
+            return StatusCode(500, ex.Message);
+        }
+    }
+
+    private List<string> DecryptAttributeMask(string attributeMask, string entityLogicalName)
+    {
+        var attributeNames = new List<string>();
+        var attributeBits = attributeMask.Split(',');
+
+        foreach (var bit in attributeBits)
+        {
+            var attributeName = GetAttributeNameByIndex(entityLogicalName, bit);
+            attributeNames.Add(attributeName);
+        }
+
+        return attributeNames;
+    }
+
+    private string GetAttributeNameByIndex(string entityLogicalName, string attributeIndex)
+    {
+        var request = new RetrieveEntityRequest
+        {
+            EntityFilters = EntityFilters.Attributes,
+            LogicalName = entityLogicalName
+        };
+
+        var response = (RetrieveEntityResponse)OrgService.Execute(request);
+        try
+        {
+            var attributeMetadata = response.EntityMetadata.Attributes.FirstOrDefault(a => a.ColumnNumber == int.Parse(attributeIndex));
+            return attributeMetadata?.LogicalName ?? string.Empty;
+        }
+        catch (Exception)
+        {
+
+            return string.Empty;
+        }
+
+
+    }
+
+    private string GetNumber(string entityName, Guid id)
+    {
+        Entity mainEntity;
+        EntityReference relatedEntity;
+        switch (entityName)
+        {
+            case "opportunity":
+                mainEntity = _helper.Retrieve(entityName, id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "new_productorder":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("new_opportunity")).GetAttributeValue<EntityReference>("new_opportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "new_productdonation":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("new_opportunity")).GetAttributeValue<EntityReference>("new_opportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "op_moratoriumtime":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("op_opportunity")).GetAttributeValue<EntityReference>("op_opportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "new_otherfocgift":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("new_opportunity")).GetAttributeValue<EntityReference>("new_opportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "new_productordertracking":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("new_opportunity")).GetAttributeValue<EntityReference>("new_opportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "new_opportunitycontact":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("new_opportunity")).GetAttributeValue<EntityReference>("new_opportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "op_opportunityletter":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("op_opportunity")).GetAttributeValue<EntityReference>("op_opportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "op_attachment":
+                relatedEntity = _helper.Retrieve(entityName, id, new ColumnSet("op_parentopportunity")).GetAttributeValue<EntityReference>("op_parentopportunity");
+                mainEntity = _helper.Retrieve(relatedEntity.LogicalName, relatedEntity.Id, new ColumnSet("new_opportunitynumber"));
+                return mainEntity.Contains("new_opportunitynumber") ? (string)mainEntity["new_opportunitynumber"] : string.Empty;
+            case "incident":
+                mainEntity = _helper.Retrieve(entityName, id, new ColumnSet("ticketnumber"));
+                return mainEntity.Contains("ticketnumber") ? (string)mainEntity["ticketnumber"] : string.Empty;
+            default:
+                return string.Empty;
+        }
+    }
+
+    private string GetAttributeValue(Entity entity, string attributeName)
+    {
+        if (entity.Contains(attributeName))
+        {
+            var attributeValue = entity[attributeName];
+            switch (attributeValue)
+            {
+                case OptionSetValue optionSetValue:
+                    return $"{GetOptionSetLabel(entity.LogicalName, attributeName, optionSetValue.Value)} ({optionSetValue.Value})";
+                case EntityReference entityReference:
+                    return $"{entityReference.Name}";
+                case Money money:
+                    return money.Value.ToString("NO");
+                case DateTime dateTime:
+                    return dateTime.ToString("o");
+                case bool boolean:
+                    return boolean.ToString();
+                case int integer:
+                    return integer.ToString();
+                case string str:
+                    return str;
+                case decimal dec:
+                    return dec.ToString();
+                case double dbl:
+                    return dbl.ToString();
+                case Guid guid:
+                    return guid.ToString();
+                case OptionSetValueCollection optionSetValueCollection:
+                    return string.Join(", ", optionSetValueCollection.Select(v => $"{GetOptionSetLabel(entity.LogicalName, attributeName, v.Value)}"));
+                default:
+                    return attributeValue.ToString();
+            }
+        }
+        return string.Empty;
+    }
+
+    private string GetOptionSetLabel(string entityLogicalName, string attributeLogicalName, int optionSetValue)
+    {
+        var request = new RetrieveAttributeRequest
+        {
+            EntityLogicalName = entityLogicalName,
+            LogicalName = attributeLogicalName,
+            RetrieveAsIfPublished = true
+        };
+
+        var response = (RetrieveAttributeResponse)OrgService.Execute(request);
+        if (response.AttributeMetadata is PicklistAttributeMetadata picklistMetadata)
+        {
+            var option = picklistMetadata.OptionSet.Options.FirstOrDefault(o => o.Value == optionSetValue);
+            return option != null ? option.Label.UserLocalizedLabel.Label : optionSetValue.ToString();
+        }
+        else if (response.AttributeMetadata is MultiSelectPicklistAttributeMetadata multiSelectMetadata)
+        {
+            var option = multiSelectMetadata.OptionSet.Options.FirstOrDefault(o => o.Value == optionSetValue);
+            return option != null ? option.Label.UserLocalizedLabel.Label : optionSetValue.ToString();
+        }
+        else
+        {
+            return string.Empty;
+        }
+    }
+
+    private string GetAttributeLabel(string entityLogicalName, string attributeLogicalName)
+    {
+        var request = new RetrieveAttributeRequest
+        {
+            EntityLogicalName = entityLogicalName,
+            LogicalName = attributeLogicalName,
+            RetrieveAsIfPublished = true
+        };
+
+        var response = (RetrieveAttributeResponse)OrgService.Execute(request);
+        return response.AttributeMetadata.DisplayName.UserLocalizedLabel.Label;
+    }
+
+    private JObject GetAuditHistoryForField(string entityName, Guid entityId, string attributeName, Guid auditId, bool isForOpportunity)
+    {
+        var number = GetNumber(entityName, entityId);
+        if (string.IsNullOrEmpty(number) && isForOpportunity)
+            return new JObject();
+
+        if (string.IsNullOrEmpty(attributeName))
+            return new JObject();
+
+        var request = new RetrieveAttributeChangeHistoryRequest
+        {
+            Target = new EntityReference(entityName, entityId),
+            AttributeLogicalName = attributeName
+        };
+
+        var response = (RetrieveAttributeChangeHistoryResponse)OrgService.Execute(request);
+        var auditDetails = response.AuditDetailCollection.AuditDetails;
+
+        var auditEntry = new JObject();
+        foreach (var detail in auditDetails)
+        {
+            try
+            {
+                var attributeAuditDetail = (AttributeAuditDetail)detail;
+                if (attributeAuditDetail.AuditRecord.Id == auditId)
+                {
+                    var oldValue = GetAttributeValue(attributeAuditDetail.OldValue, attributeName);
+                    var newValue = GetAttributeValue(attributeAuditDetail.NewValue, attributeName);
+                    var changeDate = attributeAuditDetail.AuditRecord.GetAttributeValue<DateTime>("createdon").ToLocalTime().ToString("MM-dd-yyyy HH:mm:ss");
+                    var user = attributeAuditDetail.AuditRecord.GetAttributeValue<EntityReference>("userid").Name;
+                    var operation = attributeAuditDetail.AuditRecord.GetAttributeValue<OptionSetValue>("operation").Value;
+                    var operationName = GetOptionSetLabel("audit", "operation", operation);
+                    //var action = attributeAuditDetail.AuditRecord.GetAttributeValue<OptionSetValue>("action").Value;
+                    //var actionName = GetOptionSetLabel("audit", "action", action);
+
+                    //var persianCalendar = new System.Globalization.PersianCalendar();
+                    //var persianDate = $"{persianCalendar.GetYear(changeDate)}/{persianCalendar.GetMonth(changeDate):00}/{persianCalendar.GetDayOfMonth(changeDate):00} {changeDate:HH:mm:ss}";
+
+                    var attributeLabel = GetAttributeLabel(entityName, attributeName);
+
+                    auditEntry = new JObject
+                    {
+                        ["Table Name"] = entityName,
+                        ["Record Id"] = entityId,
+                        ["Event"] = operationName,
+                        ["Change Time"] = changeDate,
+                        ["Changed Field"] = attributeLabel,
+                        ["Changed By"] = user,
+                        ["Old Value"] = oldValue,
+                        ["New Value"] = newValue
+                    };
+                    if (isForOpportunity)
+                    {
+                        auditEntry["Order Id"] = number;
+                    }
+                    else
+                    {
+                        auditEntry["Id"] = number;
+                    }
+                    break;
+                }
+            }
+            catch (Exception)
+            {
+
+                continue;
+            }
+
+        }
+
+        return auditEntry;
+    }
+}
+

--- a/Dynamics365.Merge/Common/MergeError.cs
+++ b/Dynamics365.Merge/Common/MergeError.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Dynamics365.Merge.Common
+{
+    public class MergeError
+    {
+        public int? RowNumber { get; set; }
+        public string SourceId { get; set; }
+        public string TargetId { get; set; }
+        public string Stage { get; set; }
+        public string Operation { get; set; }
+        public string RelationshipSchemaName { get; set; }
+        public Guid? RelatedRecordId { get; set; }
+        public string Message { get; set; }
+        public string Details { get; set; }
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    }
+}
+

--- a/Dynamics365.Merge/Common/MergeProgressDetail.cs
+++ b/Dynamics365.Merge/Common/MergeProgressDetail.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Dynamics365.Merge.Common
+{
+    public class MergeProgressDetail
+    {
+        public string Stage { get; set; }
+        public string Message { get; set; }
+        public string RelationshipSchemaName { get; set; }
+        public Guid? RelatedRecordId { get; set; }
+        public int? CurrentItem { get; set; }
+        public int? TotalItems { get; set; }
+        public string SourceId { get; set; }
+        public string TargetId { get; set; }
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    }
+}
+

--- a/Dynamics365.Merge/Dynamics365.Merge.csproj
+++ b/Dynamics365.Merge/Dynamics365.Merge.csproj
@@ -43,17 +43,14 @@
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.9.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.49\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.60\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.IdentityModel.Abstractions, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.6.35.0\lib\net462\Microsoft.IdentityModel.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.49\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Sdk.Workflow">
-      <HintPath>..\..\AddPrivliageFromSimilarPosition\AddPrivliageFromSimilarPosition\packages\Microsoft.CrmSdk.Workflow.9.0.2.46\lib\net462\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.60\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Activities" />
@@ -89,6 +86,12 @@
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Activities" />
+    <Reference Include="System.ServiceModel.Http, Version=4.10.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ServiceModel.Http.4.10.3\lib\net461\System.ServiceModel.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceModel.Primitives, Version=4.10.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ServiceModel.Primitives.4.10.3\lib\net461\System.ServiceModel.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Text.Encodings.Web, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encodings.Web.9.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
@@ -110,6 +113,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Helper.cs" />
+    <Compile Include="Common\MergeError.cs" />
+    <Compile Include="Common\MergeProgressDetail.cs" />
     <Compile Include="Merge.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Dynamics365.Merge/Merge.cs
+++ b/Dynamics365.Merge/Merge.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Activities;
+using System.Collections.Generic;
 using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Workflow;
 using Microsoft.Xrm.Sdk.Query;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
@@ -18,12 +18,15 @@ namespace Dynamics365.Merge
         private IOrganizationService OrgService;
         private bool FillNullsOnTargetFromSource;
         private Helper Helper;
-
         private EntityMetadata MetaData;
+        private readonly List<MergeError> _errors = new List<MergeError>();
+        private readonly int? _rowNumber;
 
         public event EventHandler<string> OnFunctionCalled;
+        public event EventHandler<MergeProgressDetail> OnProgressChanged;
+        public IReadOnlyCollection<MergeError> Errors => _errors.AsReadOnly();
 
-        public MergeRequest(string logicalName, string sourceId, string targetId, IOrganizationService orgService, bool fillNullsOnTargetFromSource)
+        public MergeRequest(string logicalName, string sourceId, string targetId, IOrganizationService orgService, bool fillNullsOnTargetFromSource, int? rowNumber = null)
         {
             LogicalName = logicalName;
             SourceId = new Guid(sourceId);
@@ -31,6 +34,39 @@ namespace Dynamics365.Merge
             this.OrgService = orgService;
             FillNullsOnTargetFromSource = fillNullsOnTargetFromSource;
             Helper = new Helper(orgService);
+            _rowNumber = rowNumber;
+        }
+
+        private void ReportProgress(string stage, string message, string relationship = null, int? current = null, int? total = null, Guid? relatedRecordId = null)
+        {
+            OnProgressChanged?.Invoke(this, new MergeProgressDetail
+            {
+                Stage = stage,
+                Message = message,
+                RelationshipSchemaName = relationship,
+                CurrentItem = current,
+                TotalItems = total,
+                RelatedRecordId = relatedRecordId,
+                SourceId = SourceId.ToString(),
+                TargetId = TargetId.ToString()
+            });
+        }
+
+        private void TrackError(string stage, string message, Exception ex, string operation = null, string relationship = null, Guid? relatedRecordId = null)
+        {
+            _errors.Add(new MergeError
+            {
+                RowNumber = _rowNumber,
+                SourceId = SourceId.ToString(),
+                TargetId = TargetId.ToString(),
+                Stage = stage,
+                Operation = operation,
+                RelationshipSchemaName = relationship,
+                RelatedRecordId = relatedRecordId,
+                Message = message,
+                Details = ex?.ToString(),
+                Timestamp = DateTime.UtcNow
+            });
         }
 
         private protected void GetEntityMetaData(string logicalName)
@@ -80,8 +116,14 @@ namespace Dynamics365.Merge
         {
             OnFunctionCalled?.Invoke(this, nameof(MergeOneToManyRelationship));
 
+            int totalRelationships = MetaData.OneToManyRelationships?.Length ?? 0;
+            int currentRelationship = 0;
+
             foreach (var item in MetaData.OneToManyRelationships)
             {
+                currentRelationship++;
+                ReportProgress(nameof(MergeOneToManyRelationship), $"Processing relationship {item.SchemaName}", item.SchemaName, currentRelationship, totalRelationships);
+
                 try
                 {
                     OneToManyRelationshipMetadata relationshipMetadata = RetrieveOneToManyRelationship(item.SchemaName);
@@ -98,13 +140,22 @@ namespace Dynamics365.Merge
                             break;
                         if (childEntity.Contains(referencingAttribute))
                         {
-                            childEntity[referencingAttribute] = new EntityReference(LogicalName, TargetId);
-                            OrgService.Update(childEntity);
+                            try
+                            {
+                                childEntity[referencingAttribute] = new EntityReference(LogicalName, TargetId);
+                                OrgService.Update(childEntity);
+                                ReportProgress(nameof(MergeOneToManyRelationship), $"Updated child record {childEntity.Id}", item.SchemaName, null, null, childEntity.Id);
+                            }
+                            catch (Exception updateEx)
+                            {
+                                TrackError(nameof(MergeOneToManyRelationship), $"Failed updating child record {childEntity.Id}", updateEx, "Update", item.SchemaName, childEntity.Id);
+                            }
                         }
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    TrackError(nameof(MergeOneToManyRelationship), $"Failed processing relationship {item.SchemaName}", ex, "RetrieveRelationship", item.SchemaName);
                     continue;
                 }
             }
@@ -151,8 +202,11 @@ namespace Dynamics365.Merge
 
             try
             {
+                int total = collection.Entities.Count;
+                int current = 0;
                 foreach (var entity2 in collection.Entities)
                 {
+                    current++;
                     AssociateEntitiesRequest request = new AssociateEntitiesRequest();
                     request.Moniker1 = new EntityReference(entity1.LogicalName, entity1.Id);
                     request.Moniker2 = new EntityReference(entity2.LogicalName, entity2.Id);
@@ -161,11 +215,12 @@ namespace Dynamics365.Merge
 
                     // Execute the request.
                     OrgService.Execute(request);
+                    ReportProgress(nameof(AssociateManyToManyEntityRecords), $"Associated record {entity2.Id}", entityRelationshipName, current, total, entity2.Id);
                 }
             }
             catch (Exception e)
             {
-                throw e.InnerException;
+                TrackError(nameof(AssociateManyToManyEntityRecords), $"Failed associating relationship {entityRelationshipName}", e, "Associate", entityRelationshipName);
             }
         }
 
@@ -173,16 +228,23 @@ namespace Dynamics365.Merge
         {
             OnFunctionCalled?.Invoke(this, nameof(MergeManyToManyRecords));
 
+            int totalRelationships = MetaData.ManyToManyRelationships?.Length ?? 0;
+            int currentRelationship = 0;
+
             foreach (var item in MetaData.ManyToManyRelationships)
             {
+                currentRelationship++;
+                ReportProgress(nameof(MergeManyToManyRecords), $"Processing many-to-many {item.SchemaName}", item.SchemaName, currentRelationship, totalRelationships);
+
                 try
                 {
                     //if (!(bool)item.IsCustomRelationship) continue;
                     EntityCollection records = RetrieveManyToManyRecords(item, new EntityReference(LogicalName, SourceId));
                     AssociateManyToManyEntityRecords(new EntityReference(LogicalName, TargetId), records, item.SchemaName);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    TrackError(nameof(MergeManyToManyRecords), $"Failed processing many-to-many {item.SchemaName}", ex, "Associate", item.SchemaName);
                     continue;
                 }
             }
@@ -219,8 +281,18 @@ namespace Dynamics365.Merge
         {
             OnFunctionCalled?.Invoke(this, nameof(MergeFields));
 
-            Entity source = GetEntity(this.SourceId);
-            Entity target = GetEntity(this.TargetId);
+            Entity source;
+            Entity target;
+            try
+            {
+                source = GetEntity(this.SourceId);
+                target = GetEntity(this.TargetId);
+            }
+            catch (Exception ex)
+            {
+                TrackError(nameof(MergeFields), "Failed retrieving source or target entity", ex, "Retrieve");
+                return;
+            }
 
             AttributeCollection columns = source.Attributes;
             foreach (var att in columns)
@@ -230,6 +302,7 @@ namespace Dynamics365.Merge
                     if (FillNullsOnTargetFromSource)
                     {
                         target.Attributes.Add(att.Key, source[att.Key]);
+                        ReportProgress(nameof(MergeFields), $"Copied field {att.Key} from source to target");
                     }
                     else
                     {
@@ -237,7 +310,14 @@ namespace Dynamics365.Merge
                     }
                 }
             }
-            OrgService.Update(target);
+            try
+            {
+                OrgService.Update(target);
+            }
+            catch (Exception ex)
+            {
+                TrackError(nameof(MergeFields), "Failed updating target entity", ex, "Update");
+            }
             //try
             //{
             //    Helper.DeactivateRecord(source.LogicalName, source.Id);
@@ -251,43 +331,19 @@ namespace Dynamics365.Merge
 
         public void DoMerge()
         {
-            GetEntityMetaData(LogicalName);
+            try
+            {
+                GetEntityMetaData(LogicalName);
+            }
+            catch (Exception ex)
+            {
+                TrackError(nameof(GetEntityMetaData), "Failed retrieving entity metadata", ex, "RetrieveMetadata");
+                return;
+            }
+
             MergeOneToManyRelationship();
             MergeManyToManyRecords();
             MergeFields();
-        }
-    }
-    public class Merge : CodeActivity
-    {
-        [Input("Logical Name")]
-        [RequiredArgument]
-        public InArgument<string> SourceLogicalName { get; set; }
-
-        [Input("Source Id")]
-        [RequiredArgument]
-        public InArgument<string> SourceId { get; set; }
-
-        [Input("Target Id")]
-        [RequiredArgument]
-        public InArgument<string> TargetId { get; set; }
-
-        private IOrganizationService orgService;
-
-        protected override void Execute(CodeActivityContext context)
-        {
-            IWorkflowContext workflow = (IWorkflowContext)context.GetExtension<IWorkflowContext>();
-            IOrganizationServiceFactory organizationServiceFactory =
-                (IOrganizationServiceFactory)context.GetExtension<IOrganizationServiceFactory>();
-            orgService = organizationServiceFactory.CreateOrganizationService(workflow.UserId);
-
-            #region GetParameters
-            string LogicalName = context.GetValue(this.SourceLogicalName);
-            string sourceId = context.GetValue(this.SourceId);
-            string targetId = context.GetValue(this.TargetId);
-            #endregion
-
-            MergeRequest merge = new MergeRequest(LogicalName, sourceId, targetId, orgService, true);
-            merge.DoMerge();
         }
     }
 }

--- a/Dynamics365.Merge/packages.config
+++ b/Dynamics365.Merge/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.0" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.49" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.60" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Abstractions" version="6.35.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.1" targetFramework="net462" />
@@ -9,6 +9,8 @@
   <package id="System.Memory" version="4.5.5" targetFramework="net462" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
+  <package id="System.ServiceModel.Http" version="4.10.3" targetFramework="net462" />
+  <package id="System.ServiceModel.Primitives" version="4.10.3" targetFramework="net462" />
   <package id="System.Text.Encodings.Web" version="9.0.0" targetFramework="net462" />
   <package id="System.Text.Json" version="9.0.0" targetFramework="net462" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />

--- a/XrmToolBox.MergeTool/MyPluginControl.cs
+++ b/XrmToolBox.MergeTool/MyPluginControl.cs
@@ -1,4 +1,5 @@
 ﻿using Dynamics365.Merge;
+using Dynamics365.Merge.Common;
 using McTools.Xrm.Connection;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
@@ -26,6 +27,11 @@ namespace XrmToolBox.MergeTool
         private DataTable excelTable;
         private List<string> errorRows;
         private int _startingrow = 1;
+        private List<MergeError> mergeErrors = new List<MergeError>();
+        private readonly Dictionary<string, Dictionary<int, string>> optionSetLabelCache = new Dictionary<string, Dictionary<int, string>>();
+        private readonly Dictionary<string, StateStatusInfo> recordStateCache = new Dictionary<string, StateStatusInfo>();
+        private string currentEntityLogicalName;
+        private ConnectionDetail connectionDetail;
 
         public MyPluginControl()
         {
@@ -101,8 +107,14 @@ namespace XrmToolBox.MergeTool
                             dataGridViewEntities.DataSource = entitiesTable;
                             txtSearch.Enabled = true;
                             btnLoadExcel.Enabled = true;
-                            dataGridViewEntities.ReadOnly = false;
+                            dataGridViewEntities.ReadOnly = true;
                             dataGridViewEntities.Enabled = true;
+                            if (dataGridViewEntities.Rows.Count > 0)
+                            {
+                                dataGridViewEntities.Rows[0].Selected = true;
+                                dataGridViewEntities.CurrentCell = dataGridViewEntities.Rows[0].Cells["Name"];
+                            }
+                            LoadEntityStateStatusPicklists(EntityLogicalName());
                         }
                     }
                 }
@@ -130,11 +142,18 @@ namespace XrmToolBox.MergeTool
             if (filteredRows.Any())
             {
                 dataGridViewEntities.DataSource = filteredRows.CopyToDataTable();
+                if (dataGridViewEntities.Rows.Count > 0)
+                {
+                    dataGridViewEntities.Rows[0].Selected = true;
+                    dataGridViewEntities.CurrentCell = dataGridViewEntities.Rows[0].Cells["Name"];
+                }
             }
             else
             {
                 dataGridViewEntities.DataSource = entitiesTable.Clone(); // Clear the DataGridView if no rows are found
             }
+
+            LoadEntityStateStatusPicklists(EntityLogicalName());
         }
 
         private void RemoveText(object sender, EventArgs e)
@@ -157,6 +176,17 @@ namespace XrmToolBox.MergeTool
 
         private void btnLoadExcel_Click(object sender, EventArgs e)
         {
+            var proceed = MessageBox.Show(
+                "Make sure the workbook you want to use is closed in Excel before continuing.\n\nDo you want to select an Excel file now?",
+                "Load Excel File",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question);
+
+            if (proceed != DialogResult.Yes)
+            {
+                return;
+            }
+
             using (OpenFileDialog openFileDialog = new OpenFileDialog())
             {
                 openFileDialog.Filter = "Excel Files|*.xlsx;*.xls";
@@ -208,6 +238,7 @@ namespace XrmToolBox.MergeTool
 
             excelTable = new DataTable();
             errorRows = new List<string>();
+            recordStateCache.Clear();
             WorkAsync(new WorkAsyncInfo
             {
                 Message = "Validating Excel file...",
@@ -222,6 +253,10 @@ namespace XrmToolBox.MergeTool
                         excelTable.Columns.Add("SourceId");
                         excelTable.Columns.Add("TargetId");
                         excelTable.Columns.Add("Status");
+                        excelTable.Columns.Add("SourceState");
+                        excelTable.Columns.Add("SourceStatus");
+                        excelTable.Columns.Add("TargetState");
+                        excelTable.Columns.Add("TargetStatus");
 
                         var guidsToCheck = new HashSet<Guid>();
 
@@ -257,6 +292,7 @@ namespace XrmToolBox.MergeTool
                                 if (existingGuids.Contains(sourceGuid) && existingGuids.Contains(targetGuid))
                                 {
                                     rowToAdd["Status"] = "Valid";
+                                    PopulateStateStatusColumns(rowToAdd, sourceGuid, targetGuid);
                                 }
                                 else
                                 {
@@ -289,6 +325,7 @@ namespace XrmToolBox.MergeTool
                     else
                     {
                         dataGridViewExcel.DataSource = args.Result;
+                        SetupCrmLinks();
                         HighlightRows();
                         ShowReport();
                         btnMerge.Enabled = true;
@@ -299,13 +336,10 @@ namespace XrmToolBox.MergeTool
 
         private string EntityLogicalName()
         {
-            foreach (DataGridViewRow row in dataGridViewEntities.Rows)
+            if (dataGridViewEntities.CurrentRow != null && dataGridViewEntities.CurrentRow.Cells["Logical Name"] != null)
             {
-                var cell = row.Cells["Select"] as DataGridViewCheckBoxCell;
-                if (cell != null && cell.Selected)
-                {
-                    return row.Cells["Logical Name"].Value.ToString();
-                }
+                var value = dataGridViewEntities.CurrentRow.Cells["Logical Name"].Value;
+                return value?.ToString();
             }
 
             return null;
@@ -360,23 +394,258 @@ namespace XrmToolBox.MergeTool
             txtErrorCount.Text = errorRowsCount.ToString();
         }
 
+        private void AppendProgressLog(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            if (txtProgressLog.TextLength > 4000)
+            {
+                txtProgressLog.Clear();
+            }
+
+            txtProgressLog.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}");
+        }
+
+        private void UpdateProgressUI(MergeProgressDetail detail, int percentage)
+        {
+            if (detail == null)
+            {
+                return;
+            }
+
+            lblProgress.Text = detail.Message;
+            if (percentage >= 0 && percentage <= 100)
+            {
+                progressBarMerge.Value = percentage;
+            }
+            AppendProgressLog($"{detail.Stage}: {detail.Message}");
+        }
+
+        private string GetOptionSetLabel(string entityLogicalName, string attributeLogicalName, int optionValue)
+        {
+            var labels = GetOrLoadOptionSetLabels(entityLogicalName, attributeLogicalName);
+            return labels.TryGetValue(optionValue, out var label) ? label : optionValue.ToString();
+        }
+
+        private Dictionary<int, string> GetOrLoadOptionSetLabels(string entityLogicalName, string attributeLogicalName)
+        {
+            if (Service == null || string.IsNullOrEmpty(entityLogicalName) || string.IsNullOrEmpty(attributeLogicalName))
+            {
+                return new Dictionary<int, string>();
+            }
+
+            string cacheKey = $"{entityLogicalName}:{attributeLogicalName}";
+            if (!optionSetLabelCache.TryGetValue(cacheKey, out var labels))
+            {
+                try
+                {
+                    var request = new RetrieveAttributeRequest
+                    {
+                        EntityLogicalName = entityLogicalName,
+                        LogicalName = attributeLogicalName,
+                        RetrieveAsIfPublished = true
+                    };
+
+                    var response = (RetrieveAttributeResponse)Service.Execute(request);
+
+                    if (response.AttributeMetadata is StateAttributeMetadata stateMetadata)
+                    {
+                        labels = stateMetadata.OptionSet.Options
+                            .Where(o => o.Value.HasValue)
+                            .ToDictionary(o => o.Value.Value, o => o.Label.UserLocalizedLabel?.Label ?? o.Value.Value.ToString());
+                    }
+                    else if (response.AttributeMetadata is StatusAttributeMetadata statusMetadata)
+                    {
+                        labels = statusMetadata.OptionSet.Options
+                            .Where(o => o.Value.HasValue)
+                            .ToDictionary(o => o.Value.Value, o => o.Label.UserLocalizedLabel?.Label ?? o.Value.Value.ToString());
+                    }
+                    else if (response.AttributeMetadata is PicklistAttributeMetadata picklistMetadata)
+                    {
+                        labels = picklistMetadata.OptionSet.Options
+                            .Where(o => o.Value.HasValue)
+                            .ToDictionary(o => o.Value.Value, o => o.Label.UserLocalizedLabel?.Label ?? o.Value.Value.ToString());
+                    }
+                    else
+                    {
+                        labels = new Dictionary<int, string>();
+                    }
+
+                    optionSetLabelCache[cacheKey] = labels;
+                }
+                catch (Exception ex)
+                {
+                    AppendProgressLog($"Unable to load option labels for {attributeLogicalName}: {ex.Message}");
+                    labels = new Dictionary<int, string>();
+                    optionSetLabelCache[cacheKey] = labels;
+                }
+            }
+
+            return labels ?? new Dictionary<int, string>();
+        }
+
+        private List<OptionItem> GetOptionItemsForAttribute(string entityLogicalName, string attributeLogicalName)
+        {
+            var labels = GetOrLoadOptionSetLabels(entityLogicalName, attributeLogicalName);
+            return labels
+                .Select(kvp => new OptionItem
+                {
+                    Value = kvp.Key,
+                    Label = string.IsNullOrEmpty(kvp.Value) ? kvp.Key.ToString() : $"{kvp.Value} ({kvp.Key})"
+                })
+                .OrderBy(item => item.Label)
+                .ToList();
+        }
+
+        private StateStatusInfo GetRecordStateStatus(Guid recordId)
+        {
+            var logicalName = EntityLogicalName();
+            if (logicalName == null)
+            {
+                return new StateStatusInfo();
+            }
+
+            var cacheKey = $"{logicalName}:{recordId}";
+            if (recordStateCache.TryGetValue(cacheKey, out var cached))
+            {
+                return cached;
+            }
+
+            try
+            {
+                var entity = Service.Retrieve(logicalName, recordId, new ColumnSet("statecode", "statuscode"));
+                string stateLabel = string.Empty;
+                string statusLabel = string.Empty;
+
+                var stateOption = entity.GetAttributeValue<OptionSetValue>("statecode");
+                if (stateOption != null)
+                {
+                    var label = GetOptionSetLabel(logicalName, "statecode", stateOption.Value);
+                    stateLabel = string.IsNullOrEmpty(label) ? stateOption.Value.ToString() : $"{label} ({stateOption.Value})";
+                }
+
+                var statusOption = entity.GetAttributeValue<OptionSetValue>("statuscode");
+                if (statusOption != null)
+                {
+                    var label = GetOptionSetLabel(logicalName, "statuscode", statusOption.Value);
+                    statusLabel = string.IsNullOrEmpty(label) ? statusOption.Value.ToString() : $"{label} ({statusOption.Value})";
+                }
+
+                var info = new StateStatusInfo
+                {
+                    StateLabel = stateLabel,
+                    StatusLabel = statusLabel
+                };
+
+                recordStateCache[cacheKey] = info;
+                return info;
+            }
+            catch (Exception ex)
+            {
+                AppendProgressLog($"Unable to retrieve state/status for record {recordId}: {ex.Message}");
+                return new StateStatusInfo();
+            }
+        }
+
+        private void PopulateStateStatusColumns(DataRow rowToAdd, Guid sourceGuid, Guid targetGuid)
+        {
+            var sourceInfo = GetRecordStateStatus(sourceGuid);
+            rowToAdd["SourceState"] = sourceInfo.StateLabel;
+            rowToAdd["SourceStatus"] = sourceInfo.StatusLabel;
+
+            var targetInfo = GetRecordStateStatus(targetGuid);
+            rowToAdd["TargetState"] = targetInfo.StateLabel;
+            rowToAdd["TargetStatus"] = targetInfo.StatusLabel;
+        }
+
+        private void LoadEntityStateStatusPicklists(string logicalName)
+        {
+            if (string.IsNullOrEmpty(logicalName))
+            {
+                cmbStateOptions.DataSource = null;
+                cmbStatusOptions.DataSource = null;
+                cmbStateOptions.Enabled = false;
+                cmbStatusOptions.Enabled = false;
+                currentEntityLogicalName = null;
+                recordStateCache.Clear();
+                return;
+            }
+
+            if (!string.Equals(currentEntityLogicalName, logicalName, StringComparison.OrdinalIgnoreCase))
+            {
+                currentEntityLogicalName = logicalName;
+                recordStateCache.Clear();
+            }
+
+            var stateItems = GetOptionItemsForAttribute(logicalName, "statecode");
+            cmbStateOptions.DataSource = stateItems;
+            cmbStateOptions.DisplayMember = "Label";
+            cmbStateOptions.ValueMember = "Value";
+            cmbStateOptions.Enabled = stateItems.Any();
+
+            var statusItems = GetOptionItemsForAttribute(logicalName, "statuscode");
+            cmbStatusOptions.DataSource = statusItems;
+            cmbStatusOptions.DisplayMember = "Label";
+            cmbStatusOptions.ValueMember = "Value";
+            cmbStatusOptions.Enabled = statusItems.Any();
+        }
+
         private void GenerateErrorReport()
         {
+            if (!errorRows.Any() && !mergeErrors.Any())
+            {
+                MessageBox.Show("There are no errors to include in the report.", "No Errors", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
             var result = MessageBox.Show("Do you want to save the error report?", "Save Error Report", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
             if (result == DialogResult.Yes)
             {
                 using (var package = new ExcelPackage())
                 {
-                    var worksheet = package.Workbook.Worksheets.Add("Error Report");
-
-                    worksheet.Cells[1, 1].Value = "Row No.";
-                    worksheet.Cells[1, 2].Value = "Error Message";
-
-                    for (int i = 0; i < errorRows.Count; i++)
+                    if (errorRows.Any())
                     {
-                        var errorRow = errorRows[i].Split(':');
-                        worksheet.Cells[i + 2, 1].Value = errorRow[0]; // Original row number
-                        worksheet.Cells[i + 2, 2].Value = errorRow[1]; // Error message
+                        var validationSheet = package.Workbook.Worksheets.Add("Validation Errors");
+                        validationSheet.Cells[1, 1].Value = "Row No.";
+                        validationSheet.Cells[1, 2].Value = "Error Message";
+
+                        for (int i = 0; i < errorRows.Count; i++)
+                        {
+                            var errorRow = errorRows[i].Split(':');
+                            validationSheet.Cells[i + 2, 1].Value = errorRow[0]; // Original row number
+                            validationSheet.Cells[i + 2, 2].Value = errorRow[1]; // Error message
+                        }
+                    }
+
+                    if (mergeErrors.Any())
+                    {
+                        var mergeSheet = package.Workbook.Worksheets.Add("Merge Errors");
+                        mergeSheet.Cells[1, 1].Value = "Row No.";
+                        mergeSheet.Cells[1, 2].Value = "Source Id";
+                        mergeSheet.Cells[1, 3].Value = "Target Id";
+                        mergeSheet.Cells[1, 4].Value = "Stage";
+                        mergeSheet.Cells[1, 5].Value = "Operation";
+                        mergeSheet.Cells[1, 6].Value = "Relationship";
+                        mergeSheet.Cells[1, 7].Value = "Related Record";
+                        mergeSheet.Cells[1, 8].Value = "Message";
+                        mergeSheet.Cells[1, 9].Value = "Details";
+
+                        for (int i = 0; i < mergeErrors.Count; i++)
+                        {
+                            var error = mergeErrors[i];
+                            mergeSheet.Cells[i + 2, 1].Value = error.RowNumber;
+                            mergeSheet.Cells[i + 2, 2].Value = error.SourceId;
+                            mergeSheet.Cells[i + 2, 3].Value = error.TargetId;
+                            mergeSheet.Cells[i + 2, 4].Value = error.Stage;
+                            mergeSheet.Cells[i + 2, 5].Value = error.Operation;
+                            mergeSheet.Cells[i + 2, 6].Value = error.RelationshipSchemaName;
+                            mergeSheet.Cells[i + 2, 7].Value = error.RelatedRecordId?.ToString();
+                            mergeSheet.Cells[i + 2, 8].Value = error.Message;
+                            mergeSheet.Cells[i + 2, 9].Value = error.Details;
+                        }
                     }
 
                     var saveFileDialog = new SaveFileDialog
@@ -428,7 +697,11 @@ namespace XrmToolBox.MergeTool
             var result = MessageBox.Show("Are you sure to start the merge process? Note that log for every row will be reported.", "Merge Process", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
             if (result == DialogResult.Yes)
             {
-
+                var reminder = MessageBox.Show("Reminder: the tool cannot bypass Dynamics 365 processes, workflows, or plugins that may block a merge. Do you still want to continue?", "Processes May Block Merge", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                if (reminder != DialogResult.Yes)
+                {
+                    return;
+                }
 
                 if (string.IsNullOrEmpty(txtFilePath.Text) || !File.Exists(txtFilePath.Text))
                 {
@@ -441,6 +714,24 @@ namespace XrmToolBox.MergeTool
                 {
                     return;
                 }
+
+                // Capture selected state/status values before async work (thread-safe)
+                int? selectedState = null;
+                int? selectedStatus = null;
+
+                if (cmbStateOptions.SelectedValue != null && cmbStateOptions.SelectedValue is int stateValue)
+                {
+                    selectedState = stateValue;
+                }
+
+                if (cmbStatusOptions.SelectedValue != null && cmbStatusOptions.SelectedValue is int statusValue)
+                {
+                    selectedStatus = statusValue;
+                }
+
+                mergeErrors = new List<MergeError>();
+                txtProgressLog.Clear();
+                progressBarMerge.Value = 0;
 
                 WorkAsync(new WorkAsyncInfo
                 {
@@ -470,17 +761,72 @@ namespace XrmToolBox.MergeTool
                                     continue;
                                 }
 
-                                worker.ReportProgress((row) * 100 / (rowCount), $"Processing row {row} of {rowCount}");
+                                int progressPercent = (row) * 100 / (rowCount);
+                                worker.ReportProgress(progressPercent, $"Processing row {row} of {rowCount}");
 
-                                MergeRequest mergeRequest = new MergeRequest(logicalName, sourceId, targetId, Service, true);
+                                MergeRequest mergeRequest = new MergeRequest(logicalName, sourceId, targetId, Service, true, row);
                                 mergeRequest.OnFunctionCalled += MergeRequest_OnFunctionCalled;
+                                EventHandler<MergeProgressDetail> progressHandler = (s, detail) =>
+                                {
+                                    worker.ReportProgress(progressPercent, detail);
+                                };
+                                mergeRequest.OnProgressChanged += progressHandler;
                                 mergeRequest.DoMerge();
+                                mergeRequest.OnProgressChanged -= progressHandler;
+
+                                // Update source record status if user has selected state/status
+                                if (Guid.TryParse(sourceId, out var sourceGuid) && (selectedState.HasValue || selectedStatus.HasValue))
+                                {
+                                    try
+                                    {
+                                        UpdateSourceRecordStatus(logicalName, sourceGuid, selectedState, selectedStatus);
+                                        worker.ReportProgress(progressPercent, $"Updated source record status for {sourceId}");
+                                    }
+                                    catch (Exception statusEx)
+                                    {
+                                        mergeErrors.Add(new MergeError
+                                        {
+                                            RowNumber = row,
+                                            SourceId = sourceId,
+                                            TargetId = targetId,
+                                            Stage = "UpdateSourceStatus",
+                                            Operation = "UpdateStatus",
+                                            Message = $"Failed updating source record {sourceId} status",
+                                            Details = statusEx?.ToString(),
+                                            Timestamp = DateTime.UtcNow
+                                        });
+                                    }
+                                }
+
+                                if (mergeRequest.Errors.Any())
+                                {
+                                    foreach (var error in mergeRequest.Errors)
+                                    {
+                                        if (!error.RowNumber.HasValue)
+                                        {
+                                            error.RowNumber = row;
+                                        }
+                                        mergeErrors.Add(error);
+                                    }
+                                }
                             }
                         }
                     },
                     ProgressChanged = (args) =>
                     {
-                        lblProgress.Text = args.UserState.ToString();
+                        if (args.UserState is MergeProgressDetail detail)
+                        {
+                            UpdateProgressUI(detail, args.ProgressPercentage);
+                        }
+                        else if (args.UserState is string message)
+                        {
+                            lblProgress.Text = message;
+                            if (args.ProgressPercentage >= 0 && args.ProgressPercentage <= 100)
+                            {
+                                progressBarMerge.Value = args.ProgressPercentage;
+                            }
+                            AppendProgressLog(message);
+                        }
                     },
                     PostWorkCallBack = (args) =>
                     {
@@ -490,7 +836,14 @@ namespace XrmToolBox.MergeTool
                         }
                         else
                         {
-                            MessageBox.Show("Bulk merge completed successfully.");
+                            if (mergeErrors.Any())
+                            {
+                                MessageBox.Show($"Bulk merge completed with {mergeErrors.Count} merge errors. Review the report for details.", "Merge Completed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            }
+                            else
+                            {
+                                MessageBox.Show("Bulk merge completed successfully.", "Merge Completed", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                            }
                         }
                         GenerateErrorReport();
                     }
@@ -501,6 +854,204 @@ namespace XrmToolBox.MergeTool
         private void MergeRequest_OnFunctionCalled(object sender, string functionName)
         {
             lblProgress.Text = $"Calling function: {functionName}";
+        }
+
+        private void UpdateSourceRecordStatus(string entityLogicalName, Guid sourceId, int? selectedState, int? selectedStatus)
+        {
+            if (Service == null || string.IsNullOrEmpty(entityLogicalName) || sourceId == Guid.Empty)
+            {
+                return;
+            }
+
+            // Only update if user has made a selection
+            if (!selectedState.HasValue && !selectedStatus.HasValue)
+            {
+                return;
+            }
+
+            Entity sourceEntity = new Entity(entityLogicalName)
+            {
+                Id = sourceId
+            };
+
+            if (selectedState.HasValue)
+            {
+                sourceEntity["statecode"] = new OptionSetValue(selectedState.Value);
+            }
+
+            if (selectedStatus.HasValue)
+            {
+                sourceEntity["statuscode"] = new OptionSetValue(selectedStatus.Value);
+            }
+
+            Service.Update(sourceEntity);
+        }
+
+        private string GetCrmBaseUrl()
+        {
+            if (connectionDetail == null || string.IsNullOrEmpty(connectionDetail.WebApplicationUrl))
+            {
+                // Try to get from settings as fallback
+                if (mySettings != null && !string.IsNullOrEmpty(mySettings.LastUsedOrganizationWebappUrl))
+                {
+                    return ExtractBaseUrl(mySettings.LastUsedOrganizationWebappUrl);
+                }
+                return null;
+            }
+
+            return ExtractBaseUrl(connectionDetail.WebApplicationUrl);
+        }
+
+        private string ExtractBaseUrl(string serviceUrl)
+        {
+            if (string.IsNullOrEmpty(serviceUrl))
+            {
+                return null;
+            }
+
+            try
+            {
+                Uri uri = new Uri(serviceUrl);
+                // Remove /XRMServices/2011/Organization.svc or similar paths
+                string baseUrl = $"{uri.Scheme}://{uri.Host}";
+                if (!string.IsNullOrEmpty(uri.AbsolutePath))
+                {
+                    // Extract the organization path (e.g., /Marketing from /Marketing/XRMServices/2011/Organization.svc)
+                    var pathParts = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (pathParts.Length > 0)
+                    {
+                        baseUrl += "/" + pathParts[0];
+                    }
+                }
+                return baseUrl;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private string GetCrmRecordUrl(string entityLogicalName, Guid recordId)
+        {
+            string baseUrl = GetCrmBaseUrl();
+            if (string.IsNullOrEmpty(baseUrl))
+            {
+                return null;
+            }
+
+            return $"{baseUrl}/main.aspx?etn={entityLogicalName}&id={recordId}&pagetype=entityrecord";
+        }
+
+        private void SetupCrmLinks()
+        {
+            if (dataGridViewExcel.Columns.Count == 0)
+            {
+                return;
+            }
+
+            var logicalName = EntityLogicalName();
+            if (string.IsNullOrEmpty(logicalName))
+            {
+                return;
+            }
+
+            // Ensure grid is enabled and selectable but read-only
+            dataGridViewExcel.Enabled = true;
+            dataGridViewExcel.ReadOnly = true;
+            dataGridViewExcel.SelectionMode = DataGridViewSelectionMode.CellSelect;
+
+            // Remove any existing event handlers to avoid duplicates
+            dataGridViewExcel.CellContentClick -= DataGridViewExcel_CellContentClick;
+
+            // Handle cell click to open both source and target links
+            // Use only CellContentClick to avoid duplicate events
+            dataGridViewExcel.CellContentClick += DataGridViewExcel_CellContentClick;
+
+            // Format SourceId and TargetId columns to show as links
+            foreach (DataGridViewColumn column in dataGridViewExcel.Columns)
+            {
+                if (column.Name == "SourceId" || column.Name == "TargetId")
+                {
+                    column.DefaultCellStyle.ForeColor = Color.Blue;
+                    column.DefaultCellStyle.Font = new Font(dataGridViewExcel.DefaultCellStyle.Font, FontStyle.Underline);
+                }
+            }
+        }
+
+        private void DataGridViewExcel_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0 || e.ColumnIndex < 0)
+            {
+                return;
+            }
+
+            var columnName = dataGridViewExcel.Columns[e.ColumnIndex].Name;
+            // If clicking on SourceId or TargetId, open both source and target links
+            if (columnName == "SourceId" || columnName == "TargetId")
+            {
+                OpenBothCrmLinks(e.RowIndex);
+            }
+        }
+
+        private void OpenBothCrmLinks(int rowIndex)
+        {
+            var logicalName = EntityLogicalName();
+            if (string.IsNullOrEmpty(logicalName))
+            {
+                return;
+            }
+
+            var sourceIdColumn = dataGridViewExcel.Columns["SourceId"];
+            var targetIdColumn = dataGridViewExcel.Columns["TargetId"];
+
+            if (sourceIdColumn == null || targetIdColumn == null)
+            {
+                return;
+            }
+
+            // Open source link
+            var sourceValue = dataGridViewExcel.Rows[rowIndex].Cells["SourceId"].Value?.ToString();
+            if (Guid.TryParse(sourceValue, out var sourceId))
+            {
+                string sourceUrl = GetCrmRecordUrl(logicalName, sourceId);
+                if (!string.IsNullOrEmpty(sourceUrl))
+                {
+                    try
+                    {
+                        System.Diagnostics.Process.Start(sourceUrl);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Unable to open source CRM link: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
+                }
+            }
+
+            // Small delay to avoid opening both at exactly the same time
+            System.Threading.Thread.Sleep(100);
+
+            // Open target link
+            var targetValue = dataGridViewExcel.Rows[rowIndex].Cells["TargetId"].Value?.ToString();
+            if (Guid.TryParse(targetValue, out var targetId))
+            {
+                string targetUrl = GetCrmRecordUrl(logicalName, targetId);
+                if (!string.IsNullOrEmpty(targetUrl))
+                {
+                    try
+                    {
+                        System.Diagnostics.Process.Start(targetUrl);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Unable to open target CRM link: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
+                }
+            }
+        }
+
+        private void dataGridViewEntities_SelectionChanged(object sender, EventArgs e)
+        {
+            LoadEntityStateStatusPicklists(EntityLogicalName());
         }
 
         private void tsbClose_Click(object sender, EventArgs e)
@@ -526,6 +1077,8 @@ namespace XrmToolBox.MergeTool
         {
             base.UpdateConnection(newService, detail, actionName, parameter);
 
+            connectionDetail = detail;
+
             if (mySettings != null && detail != null)
             {
                 mySettings.LastUsedOrganizationWebappUrl = detail.WebApplicationUrl;
@@ -533,5 +1086,16 @@ namespace XrmToolBox.MergeTool
             }
         }
 
+        private class StateStatusInfo
+        {
+            public string StateLabel { get; set; }
+            public string StatusLabel { get; set; }
+        }
+
+        private class OptionItem
+        {
+            public int Value { get; set; }
+            public string Label { get; set; }
+        }
     }
 }

--- a/XrmToolBox.MergeTool/MyPluginControl.designer.cs
+++ b/XrmToolBox.MergeTool/MyPluginControl.designer.cs
@@ -6,27 +6,44 @@ namespace XrmToolBox.MergeTool
 {
     partial class MyPluginControl
     {
-        private DataGridViewCheckBoxColumn Select;
-
         private System.ComponentModel.IContainer components = null;
         private System.Windows.Forms.ToolStrip toolStripMenu;
         private System.Windows.Forms.ToolStripButton btnLoadEntities;
         private System.Windows.Forms.ToolStripButton btnLoadExcel;
         private System.Windows.Forms.ToolStripButton btnValidateExcel;
         private System.Windows.Forms.ToolStripButton btnMerge;
-        private System.Windows.Forms.DataGridView dataGridViewEntities;
-        private System.Windows.Forms.DataGridView dataGridViewExcel;
+        private System.Windows.Forms.ToolStripButton btnHelp;
+        private System.Windows.Forms.SplitContainer splitContainerMain;
+        private System.Windows.Forms.GroupBox grpEntities;
+        private System.Windows.Forms.GroupBox grpExcel;
+        private System.Windows.Forms.TableLayoutPanel tableEntityLayout;
+        private System.Windows.Forms.Label lblGuideLoadEntities;
+        private System.Windows.Forms.Label lblGuideSearch;
+        private System.Windows.Forms.Panel panelEntitySearch;
         private System.Windows.Forms.TextBox txtSearch;
+        private System.Windows.Forms.Label lblGuideStatus;
+        private System.Windows.Forms.TableLayoutPanel tableStateStatus;
+        private System.Windows.Forms.Label lblState;
+        private System.Windows.Forms.Label lblStatus;
+        private System.Windows.Forms.ComboBox cmbStateOptions;
+        private System.Windows.Forms.ComboBox cmbStatusOptions;
+        private System.Windows.Forms.DataGridView dataGridViewEntities;
+        private System.Windows.Forms.TableLayoutPanel tableExcelLayout;
+        private System.Windows.Forms.Label lblGuideLoadExcel;
+        private System.Windows.Forms.Panel panelExcelPath;
+        private System.Windows.Forms.Label lblExcelFile;
         private System.Windows.Forms.TextBox txtFilePath;
+        private System.Windows.Forms.Label lblGuideValidate;
+        private System.Windows.Forms.Panel panelExcelGrid;
+        private System.Windows.Forms.DataGridView dataGridViewExcel;
+        private System.Windows.Forms.Panel footerPanel;
+        private System.Windows.Forms.Panel footerInfoPanel;
         private System.Windows.Forms.TextBox txtErrorCount;
         private System.Windows.Forms.TextBox txtTotalCount;
         private System.Windows.Forms.Label lblProgress;
         private System.Windows.Forms.Label lblReport;
-        private System.Windows.Forms.Panel footerPanel;
-        private System.Windows.Forms.ToolStripButton btnHelp;
-
-
-
+        private System.Windows.Forms.TextBox txtProgressLog;
+        private System.Windows.Forms.ProgressBar progressBarMerge;
 
         protected override void Dispose(bool disposing)
         {
@@ -45,21 +62,50 @@ namespace XrmToolBox.MergeTool
             this.btnValidateExcel = new System.Windows.Forms.ToolStripButton();
             this.btnMerge = new System.Windows.Forms.ToolStripButton();
             this.btnHelp = new System.Windows.Forms.ToolStripButton();
+            this.splitContainerMain = new System.Windows.Forms.SplitContainer();
+            this.grpEntities = new System.Windows.Forms.GroupBox();
+            this.tableEntityLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.lblGuideLoadEntities = new System.Windows.Forms.Label();
+            this.lblGuideSearch = new System.Windows.Forms.Label();
+            this.panelEntitySearch = new System.Windows.Forms.Panel();
             this.dataGridViewEntities = new System.Windows.Forms.DataGridView();
-            this.Select = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.dataGridViewExcel = new System.Windows.Forms.DataGridView();
+            this.tableStateStatus = new System.Windows.Forms.TableLayoutPanel();
+            this.lblState = new System.Windows.Forms.Label();
+            this.cmbStateOptions = new System.Windows.Forms.ComboBox();
+            this.lblStatus = new System.Windows.Forms.Label();
+            this.cmbStatusOptions = new System.Windows.Forms.ComboBox();
+            this.lblGuideStatus = new System.Windows.Forms.Label();
             this.txtSearch = new System.Windows.Forms.TextBox();
+            this.grpExcel = new System.Windows.Forms.GroupBox();
+            this.tableExcelLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.lblGuideLoadExcel = new System.Windows.Forms.Label();
+            this.panelExcelPath = new System.Windows.Forms.Panel();
             this.txtFilePath = new System.Windows.Forms.TextBox();
+            this.lblExcelFile = new System.Windows.Forms.Label();
+            this.lblGuideValidate = new System.Windows.Forms.Label();
+            this.panelExcelGrid = new System.Windows.Forms.Panel();
+            this.dataGridViewExcel = new System.Windows.Forms.DataGridView();
+            this.footerPanel = new System.Windows.Forms.Panel();
+            this.txtProgressLog = new System.Windows.Forms.TextBox();
+            this.progressBarMerge = new System.Windows.Forms.ProgressBar();
+            this.footerInfoPanel = new System.Windows.Forms.Panel();
+            this.txtTotalCount = new System.Windows.Forms.TextBox();
+            this.txtErrorCount = new System.Windows.Forms.TextBox();
             this.lblProgress = new System.Windows.Forms.Label();
             this.lblReport = new System.Windows.Forms.Label();
-            this.txtErrorCount = new System.Windows.Forms.TextBox();
-            this.txtTotalCount = new System.Windows.Forms.TextBox();
-            this.footerPanel = new System.Windows.Forms.Panel();
-
             this.toolStripMenu.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
+            this.splitContainerMain.Panel1.SuspendLayout();
+            this.splitContainerMain.Panel2.SuspendLayout();
+            this.splitContainerMain.SuspendLayout();
+            this.grpEntities.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEntities)).BeginInit();
+            this.tableStateStatus.SuspendLayout();
+            this.grpExcel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewExcel)).BeginInit();
+            this.panelExcelPath.SuspendLayout();
             this.footerPanel.SuspendLayout();
+            this.footerInfoPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // toolStripMenu
@@ -76,14 +122,6 @@ namespace XrmToolBox.MergeTool
             this.toolStripMenu.Size = new System.Drawing.Size(553, 31);
             this.toolStripMenu.TabIndex = 0;
             this.toolStripMenu.Text = "toolStripMenu";
-            // 
-            // btnHelp
-            // 
-            this.btnHelp.Image = global::XrmToolBox.MergeTool.Properties.Resources.help_icon; // Add an appropriate image
-            this.btnHelp.Name = "btnHelp";
-            this.btnHelp.Size = new System.Drawing.Size(53, 28);
-            this.btnHelp.Text = "Help";
-            this.btnHelp.Click += new System.EventHandler(this.btnHelp_Click);
             // 
             // btnLoadEntities
             // 
@@ -120,178 +158,447 @@ namespace XrmToolBox.MergeTool
             this.btnMerge.Text = "Merge";
             this.btnMerge.Click += new System.EventHandler(this.btnMerge_Click);
             // 
+            // btnHelp
+            // 
+            this.btnHelp.Image = global::XrmToolBox.MergeTool.Properties.Resources.help_icon;
+            this.btnHelp.Name = "btnHelp";
+            this.btnHelp.Size = new System.Drawing.Size(53, 28);
+            this.btnHelp.Text = "Help";
+            this.btnHelp.Click += new System.EventHandler(this.btnHelp_Click);
+            // 
+            // splitContainerMain
+            // 
+            this.splitContainerMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerMain.Location = new System.Drawing.Point(0, 31);
+            this.splitContainerMain.Margin = new System.Windows.Forms.Padding(2);
+            this.splitContainerMain.Name = "splitContainerMain";
+            this.splitContainerMain.Size = new System.Drawing.Size(553, 329);
+            this.splitContainerMain.SplitterDistance = 262;
+            this.splitContainerMain.TabIndex = 1;
+            // 
+            // grpEntities
+            // 
+            this.grpEntities.Controls.Add(this.tableEntityLayout);
+            this.grpEntities.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpEntities.Location = new System.Drawing.Point(0, 0);
+            this.grpEntities.Margin = new System.Windows.Forms.Padding(8);
+            this.grpEntities.Name = "grpEntities";
+            this.grpEntities.Padding = new System.Windows.Forms.Padding(8);
+            this.grpEntities.Size = new System.Drawing.Size(262, 329);
+            this.grpEntities.TabIndex = 0;
+            this.grpEntities.TabStop = false;
+            this.grpEntities.Text = "Entities";
+            // 
             // dataGridViewEntities
             // 
+            this.dataGridViewEntities.AllowUserToAddRows = false;
+            this.dataGridViewEntities.AllowUserToDeleteRows = false;
             this.dataGridViewEntities.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.dataGridViewEntities.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewEntities.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Select});
-            this.dataGridViewEntities.Enabled = false;
-            this.dataGridViewEntities.Location = new System.Drawing.Point(8, 63);
+            this.dataGridViewEntities.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataGridViewEntities.Margin = new System.Windows.Forms.Padding(2);
             this.dataGridViewEntities.Name = "dataGridViewEntities";
+            this.dataGridViewEntities.ReadOnly = true;
             this.dataGridViewEntities.RowHeadersWidth = 62;
             this.dataGridViewEntities.RowTemplate.Height = 28;
-            this.dataGridViewEntities.Size = new System.Drawing.Size(267, 260);
-            this.dataGridViewEntities.TabIndex = 1;
-            this.dataGridViewEntities.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dataGridViewEntities_CellContentClick);
+            this.dataGridViewEntities.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dataGridViewEntities.TabIndex = 5;
+            this.dataGridViewEntities.SelectionChanged += new System.EventHandler(this.dataGridViewEntities_SelectionChanged);
             // 
-            // Select
+            // tableEntityLayout
             // 
-            this.Select.HeaderText = "Select";
-            this.Select.Name = "Select";
+            this.tableEntityLayout.ColumnCount = 1;
+            this.tableEntityLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableEntityLayout.Controls.Add(this.lblGuideLoadEntities, 0, 0);
+            this.tableEntityLayout.Controls.Add(this.lblGuideSearch, 0, 1);
+            this.tableEntityLayout.Controls.Add(this.panelEntitySearch, 0, 2);
+            this.tableEntityLayout.Controls.Add(this.dataGridViewEntities, 0, 3);
+            this.tableEntityLayout.Controls.Add(this.lblGuideStatus, 0, 4);
+            this.tableEntityLayout.Controls.Add(this.tableStateStatus, 0, 5);
+            this.tableEntityLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableEntityLayout.Location = new System.Drawing.Point(8, 23);
+            this.tableEntityLayout.Name = "tableEntityLayout";
+            this.tableEntityLayout.RowCount = 6;
+            this.tableEntityLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableEntityLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableEntityLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
+            this.tableEntityLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableEntityLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableEntityLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 82F));
+            this.tableEntityLayout.Size = new System.Drawing.Size(246, 298);
+            this.tableEntityLayout.TabIndex = 0;
             // 
-            // dataGridViewExcel
+            // lblGuideLoadEntities
             // 
-            this.dataGridViewExcel.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
-            this.dataGridViewExcel.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridViewExcel.Enabled = false;
-            this.dataGridViewExcel.Location = new System.Drawing.Point(279, 63);
-            this.dataGridViewExcel.Margin = new System.Windows.Forms.Padding(2);
-            this.dataGridViewExcel.Name = "dataGridViewExcel";
-            this.dataGridViewExcel.RowHeadersWidth = 62;
-            this.dataGridViewExcel.RowTemplate.Height = 28;
-            this.dataGridViewExcel.Size = new System.Drawing.Size(267, 260);
-            this.dataGridViewExcel.TabIndex = 2;
+            this.lblGuideLoadEntities.AutoSize = true;
+            this.lblGuideLoadEntities.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblGuideLoadEntities.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Bold);
+            this.lblGuideLoadEntities.Location = new System.Drawing.Point(3, 0);
+            this.lblGuideLoadEntities.Name = "lblGuideLoadEntities";
+            this.lblGuideLoadEntities.Size = new System.Drawing.Size(240, 24);
+            this.lblGuideLoadEntities.TabIndex = 0;
+            this.lblGuideLoadEntities.Text = "1. Load entities.";
+            this.lblGuideLoadEntities.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblGuideLoadEntities.Padding = new System.Windows.Forms.Padding(0, 0, 0, 4);
+            // 
+            // lblGuideSearch
+            // 
+            this.lblGuideSearch.AutoSize = true;
+            this.lblGuideSearch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblGuideSearch.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Bold);
+            this.lblGuideSearch.Location = new System.Drawing.Point(3, 24);
+            this.lblGuideSearch.Name = "lblGuideSearch";
+            this.lblGuideSearch.Size = new System.Drawing.Size(240, 24);
+            this.lblGuideSearch.TabIndex = 1;
+            this.lblGuideSearch.Text = "2. Search and highlight an entity.";
+            this.lblGuideSearch.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblGuideSearch.Padding = new System.Windows.Forms.Padding(0, 0, 0, 4);
+            // 
+            // panelEntitySearch
+            // 
+            this.panelEntitySearch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelEntitySearch.Controls.Add(this.txtSearch);
+            this.panelEntitySearch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelEntitySearch.Location = new System.Drawing.Point(3, 51);
+            this.panelEntitySearch.Name = "panelEntitySearch";
+            this.panelEntitySearch.Padding = new System.Windows.Forms.Padding(3);
+            this.panelEntitySearch.Size = new System.Drawing.Size(240, 29);
+            this.panelEntitySearch.TabIndex = 2;
+            // 
+            // lblGuideStatus
+            // 
+            this.lblGuideStatus.AutoSize = true;
+            this.lblGuideStatus.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblGuideStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Bold);
+            this.lblGuideStatus.Name = "lblGuideStatus";
+            this.lblGuideStatus.TabIndex = 3;
+            this.lblGuideStatus.Text = "3. Choose state/status for merged-from.";
+            this.lblGuideStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblGuideStatus.Padding = new System.Windows.Forms.Padding(0, 0, 0, 4);
             // 
             // txtSearch
             // 
+            this.txtSearch.Dock = System.Windows.Forms.DockStyle.Fill;
             this.txtSearch.Enabled = false;
             this.txtSearch.ForeColor = System.Drawing.Color.Gray;
-            this.txtSearch.Location = new System.Drawing.Point(8, 42);
+            this.txtSearch.Location = new System.Drawing.Point(3, 3);
             this.txtSearch.Margin = new System.Windows.Forms.Padding(2);
             this.txtSearch.Name = "txtSearch";
-            this.txtSearch.Size = new System.Drawing.Size(135, 20);
-            this.txtSearch.TabIndex = 3;
+            this.txtSearch.Size = new System.Drawing.Size(232, 20);
+            this.txtSearch.TabIndex = 0;
             this.txtSearch.Text = "Search...";
             this.txtSearch.TextChanged += new System.EventHandler(this.txtSearch_TextChanged);
             this.txtSearch.GotFocus += new System.EventHandler(this.RemoveText);
             this.txtSearch.LostFocus += new System.EventHandler(this.AddText);
             // 
+            // tableStateStatus
+            // 
+            this.tableStateStatus.ColumnCount = 2;
+            this.tableStateStatus.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.tableStateStatus.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableStateStatus.Controls.Add(this.lblState, 0, 0);
+            this.tableStateStatus.Controls.Add(this.cmbStateOptions, 1, 0);
+            this.tableStateStatus.Controls.Add(this.lblStatus, 0, 1);
+            this.tableStateStatus.Controls.Add(this.cmbStatusOptions, 1, 1);
+            this.tableStateStatus.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableStateStatus.Margin = new System.Windows.Forms.Padding(3);
+            this.tableStateStatus.Name = "tableStateStatus";
+            this.tableStateStatus.RowCount = 2;
+            this.tableStateStatus.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableStateStatus.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableStateStatus.TabIndex = 1;
+            // 
+            // lblState
+            // 
+            this.lblState.AutoSize = true;
+            this.lblState.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblState.Location = new System.Drawing.Point(2, 0);
+            this.lblState.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblState.Name = "lblState";
+            this.lblState.Size = new System.Drawing.Size(33, 28);
+            this.lblState.TabIndex = 0;
+            this.lblState.Text = "State:";
+            this.lblState.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // cmbStateOptions
+            // 
+            this.cmbStateOptions.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.cmbStateOptions.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbStateOptions.Enabled = false;
+            this.cmbStateOptions.FormattingEnabled = true;
+            this.cmbStateOptions.Location = new System.Drawing.Point(39, 2);
+            this.cmbStateOptions.Margin = new System.Windows.Forms.Padding(2);
+            this.cmbStateOptions.Name = "cmbStateOptions";
+            this.cmbStateOptions.Size = new System.Drawing.Size(205, 21);
+            this.cmbStateOptions.TabIndex = 1;
+            // 
+            // lblStatus
+            // 
+            this.lblStatus.AutoSize = true;
+            this.lblStatus.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblStatus.Location = new System.Drawing.Point(2, 28);
+            this.lblStatus.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblStatus.Name = "lblStatus";
+            this.lblStatus.Size = new System.Drawing.Size(33, 30);
+            this.lblStatus.TabIndex = 2;
+            this.lblStatus.Text = "Status:";
+            this.lblStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // cmbStatusOptions
+            // 
+            this.cmbStatusOptions.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.cmbStatusOptions.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbStatusOptions.Enabled = false;
+            this.cmbStatusOptions.FormattingEnabled = true;
+            this.cmbStatusOptions.Location = new System.Drawing.Point(39, 30);
+            this.cmbStatusOptions.Margin = new System.Windows.Forms.Padding(2);
+            this.cmbStatusOptions.Name = "cmbStatusOptions";
+            this.cmbStatusOptions.Size = new System.Drawing.Size(205, 21);
+            this.cmbStatusOptions.TabIndex = 3;
+            // 
+            // 
+            // grpExcel
+            // 
+            this.grpExcel.Controls.Add(this.tableExcelLayout);
+            this.grpExcel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grpExcel.Location = new System.Drawing.Point(0, 0);
+            this.grpExcel.Margin = new System.Windows.Forms.Padding(8);
+            this.grpExcel.Name = "grpExcel";
+            this.grpExcel.Padding = new System.Windows.Forms.Padding(8);
+            this.grpExcel.Size = new System.Drawing.Size(287, 329);
+            this.grpExcel.TabIndex = 0;
+            this.grpExcel.TabStop = false;
+            this.grpExcel.Text = "Excel Validation";
+            // 
+            // tableExcelLayout
+            // 
+            this.tableExcelLayout.ColumnCount = 1;
+            this.tableExcelLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableExcelLayout.Controls.Add(this.lblGuideLoadExcel, 0, 0);
+            this.tableExcelLayout.Controls.Add(this.panelExcelPath, 0, 1);
+            this.tableExcelLayout.Controls.Add(this.lblGuideValidate, 0, 2);
+            this.tableExcelLayout.Controls.Add(this.panelExcelGrid, 0, 3);
+            this.tableExcelLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableExcelLayout.Location = new System.Drawing.Point(8, 23);
+            this.tableExcelLayout.Name = "tableExcelLayout";
+            this.tableExcelLayout.RowCount = 4;
+            this.tableExcelLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableExcelLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60F));
+            this.tableExcelLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableExcelLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableExcelLayout.Size = new System.Drawing.Size(271, 298);
+            this.tableExcelLayout.TabIndex = 0;
+            // 
+            // lblGuideLoadExcel
+            // 
+            this.lblGuideLoadExcel.AutoSize = true;
+            this.lblGuideLoadExcel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblGuideLoadExcel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Bold);
+            this.lblGuideLoadExcel.Location = new System.Drawing.Point(3, 0);
+            this.lblGuideLoadExcel.Name = "lblGuideLoadExcel";
+            this.lblGuideLoadExcel.Size = new System.Drawing.Size(265, 24);
+            this.lblGuideLoadExcel.TabIndex = 0;
+            this.lblGuideLoadExcel.Text = "4. Load the Excel file.";
+            this.lblGuideLoadExcel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // panelExcelPath
+            // 
+            this.panelExcelPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelExcelPath.Controls.Add(this.txtFilePath);
+            this.panelExcelPath.Controls.Add(this.lblExcelFile);
+            this.panelExcelPath.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelExcelPath.Location = new System.Drawing.Point(3, 27);
+            this.panelExcelPath.Name = "panelExcelPath";
+            this.panelExcelPath.Padding = new System.Windows.Forms.Padding(3);
+            this.panelExcelPath.Size = new System.Drawing.Size(265, 54);
+            this.panelExcelPath.TabIndex = 1;
+            // 
             // txtFilePath
             // 
-            this.txtFilePath.Location = new System.Drawing.Point(279, 42);
+            this.txtFilePath.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtFilePath.Location = new System.Drawing.Point(76, 3);
             this.txtFilePath.Margin = new System.Windows.Forms.Padding(2);
             this.txtFilePath.Name = "txtFilePath";
             this.txtFilePath.ReadOnly = true;
-            this.txtFilePath.Size = new System.Drawing.Size(268, 20);
-            this.txtFilePath.TabIndex = 4;
+            this.txtFilePath.Size = new System.Drawing.Size(184, 20);
+            this.txtFilePath.TabIndex = 1;
             // 
-            // lblProgress
+            // lblExcelFile
             // 
-            this.lblProgress.AutoSize = true;
-            this.lblProgress.Location = new System.Drawing.Point(2, 19);
-            this.lblProgress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblProgress.Name = "lblProgress";
-            this.lblProgress.Size = new System.Drawing.Size(0, 13);
-            this.lblProgress.TabIndex = 6;
+            this.lblExcelFile.AutoSize = true;
+            this.lblExcelFile.Dock = System.Windows.Forms.DockStyle.Left;
+            this.lblExcelFile.Location = new System.Drawing.Point(3, 3);
+            this.lblExcelFile.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblExcelFile.Name = "lblExcelFile";
+            this.lblExcelFile.Padding = new System.Windows.Forms.Padding(0, 4, 6, 0);
+            this.lblExcelFile.Size = new System.Drawing.Size(73, 17);
+            this.lblExcelFile.TabIndex = 0;
+            this.lblExcelFile.Text = "Excel path:";
             // 
-            // lblReport
+            // lblGuideValidate
             // 
-            this.lblReport.AutoSize = true;
-            this.lblReport.Location = new System.Drawing.Point(0, 6);
-            this.lblReport.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.lblReport.Name = "lblReport";
-            this.lblReport.Size = new System.Drawing.Size(0, 13);
-            this.lblReport.TabIndex = 7;
+            this.lblGuideValidate.AutoSize = true;
+            this.lblGuideValidate.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblGuideValidate.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.5F, System.Drawing.FontStyle.Bold);
+            this.lblGuideValidate.Location = new System.Drawing.Point(3, 84);
+            this.lblGuideValidate.Name = "lblGuideValidate";
+            this.lblGuideValidate.Size = new System.Drawing.Size(265, 24);
+            this.lblGuideValidate.TabIndex = 2;
+            this.lblGuideValidate.Text = "5. Validate Excel before merging.";
+            this.lblGuideValidate.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // panelExcelGrid
+            // 
+            this.panelExcelGrid.AutoScroll = true;
+            this.panelExcelGrid.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panelExcelGrid.Controls.Add(this.dataGridViewExcel);
+            this.panelExcelGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelExcelGrid.Location = new System.Drawing.Point(3, 111);
+            this.panelExcelGrid.Name = "panelExcelGrid";
+            this.panelExcelGrid.Padding = new System.Windows.Forms.Padding(0, 5, 0, 0);
+            this.panelExcelGrid.Size = new System.Drawing.Size(265, 184);
+            this.panelExcelGrid.TabIndex = 3;
+            // 
+            // dataGridViewExcel
+            // 
+            this.dataGridViewExcel.AllowUserToAddRows = false;
+            this.dataGridViewExcel.AllowUserToDeleteRows = false;
+            this.dataGridViewExcel.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewExcel.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewExcel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataGridViewExcel.Enabled = true;
+            this.dataGridViewExcel.ReadOnly = true;
+            this.dataGridViewExcel.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.dataGridViewExcel.Location = new System.Drawing.Point(0, 5);
+            this.dataGridViewExcel.Margin = new System.Windows.Forms.Padding(2);
+            this.dataGridViewExcel.Name = "dataGridViewExcel";
+            this.dataGridViewExcel.RowHeadersWidth = 62;
+            this.dataGridViewExcel.RowTemplate.Height = 28;
+            this.dataGridViewExcel.Size = new System.Drawing.Size(263, 177);
+            this.dataGridViewExcel.TabIndex = 0;
+            // 
+            // footerPanel
+            // 
+            this.footerPanel.Controls.Add(this.txtProgressLog);
+            this.footerPanel.Controls.Add(this.progressBarMerge);
+            this.footerPanel.Controls.Add(this.footerInfoPanel);
+            this.footerPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.footerPanel.Location = new System.Drawing.Point(0, 360);
+            this.footerPanel.Margin = new System.Windows.Forms.Padding(2);
+            this.footerPanel.Name = "footerPanel";
+            this.footerPanel.Padding = new System.Windows.Forms.Padding(5);
+            this.footerPanel.Size = new System.Drawing.Size(553, 140);
+            this.footerPanel.TabIndex = 2;
+            // 
+            // txtProgressLog
+            // 
+            this.txtProgressLog.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtProgressLog.Location = new System.Drawing.Point(5, 45);
+            this.txtProgressLog.Margin = new System.Windows.Forms.Padding(2);
+            this.txtProgressLog.Multiline = true;
+            this.txtProgressLog.Name = "txtProgressLog";
+            this.txtProgressLog.ReadOnly = true;
+            this.txtProgressLog.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtProgressLog.Size = new System.Drawing.Size(543, 70);
+            this.txtProgressLog.TabIndex = 2;
+            // 
+            // progressBarMerge
+            // 
+            this.progressBarMerge.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.progressBarMerge.Location = new System.Drawing.Point(5, 115);
+            this.progressBarMerge.Margin = new System.Windows.Forms.Padding(2);
+            this.progressBarMerge.Name = "progressBarMerge";
+            this.progressBarMerge.Size = new System.Drawing.Size(543, 20);
+            this.progressBarMerge.TabIndex = 1;
+            // 
+            // footerInfoPanel
+            // 
+            this.footerInfoPanel.Controls.Add(this.txtTotalCount);
+            this.footerInfoPanel.Controls.Add(this.txtErrorCount);
+            this.footerInfoPanel.Controls.Add(this.lblProgress);
+            this.footerInfoPanel.Controls.Add(this.lblReport);
+            this.footerInfoPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.footerInfoPanel.Location = new System.Drawing.Point(5, 5);
+            this.footerInfoPanel.Margin = new System.Windows.Forms.Padding(2);
+            this.footerInfoPanel.Name = "footerInfoPanel";
+            this.footerInfoPanel.Size = new System.Drawing.Size(543, 40);
+            this.footerInfoPanel.TabIndex = 0;
+            // 
+            // txtTotalCount
+            // 
+            this.txtTotalCount.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
+            this.txtTotalCount.Location = new System.Drawing.Point(480, 5);
+            this.txtTotalCount.Margin = new System.Windows.Forms.Padding(2);
+            this.txtTotalCount.Name = "txtTotalCount";
+            this.txtTotalCount.ReadOnly = true;
+            this.txtTotalCount.Size = new System.Drawing.Size(50, 26);
+            this.txtTotalCount.TabIndex = 4;
             // 
             // txtErrorCount
             // 
             this.txtErrorCount.BackColor = System.Drawing.Color.LightCoral;
             this.txtErrorCount.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
-            this.txtErrorCount.Location = new System.Drawing.Point(300, 2);
+            this.txtErrorCount.Location = new System.Drawing.Point(420, 5);
             this.txtErrorCount.Margin = new System.Windows.Forms.Padding(2);
             this.txtErrorCount.Name = "txtErrorCount";
             this.txtErrorCount.ReadOnly = true;
             this.txtErrorCount.Size = new System.Drawing.Size(50, 26);
-            this.txtErrorCount.TabIndex = 8;
+            this.txtErrorCount.TabIndex = 3;
             // 
-            // txtTotalCount
+            // lblProgress
             // 
-            this.txtTotalCount.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
-            this.txtTotalCount.Location = new System.Drawing.Point(365, 2);
-            this.txtTotalCount.Margin = new System.Windows.Forms.Padding(2);
-            this.txtTotalCount.Name = "txtTotalCount";
-            this.txtTotalCount.ReadOnly = true;
-            this.txtTotalCount.Size = new System.Drawing.Size(50, 26);
-            this.txtTotalCount.TabIndex = 9;
+            this.lblProgress.AutoSize = true;
+            this.lblProgress.Location = new System.Drawing.Point(5, 23);
+            this.lblProgress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblProgress.Name = "lblProgress";
+            this.lblProgress.Size = new System.Drawing.Size(0, 13);
+            this.lblProgress.TabIndex = 2;
             // 
-            // footerPanel
+            // lblReport
             // 
-            this.footerPanel.Controls.Add(this.txtErrorCount);
-            this.footerPanel.Controls.Add(this.txtTotalCount);
-            this.footerPanel.Controls.Add(this.lblProgress);
-            this.footerPanel.Controls.Add(this.lblReport);
-            this.footerPanel.Location = new System.Drawing.Point(8, 327);
-            this.footerPanel.Margin = new System.Windows.Forms.Padding(2);
-            this.footerPanel.Name = "footerPanel";
-            this.footerPanel.Size = new System.Drawing.Size(533, 67);
-            this.footerPanel.TabIndex = 10;
+            this.lblReport.AutoSize = true;
+            this.lblReport.Location = new System.Drawing.Point(5, 5);
+            this.lblReport.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblReport.Name = "lblReport";
+            this.lblReport.Size = new System.Drawing.Size(0, 13);
+            this.lblReport.TabIndex = 1;
             // 
             // MyPluginControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.txtFilePath);
-            this.Controls.Add(this.txtSearch);
-            this.Controls.Add(this.dataGridViewExcel);
-            this.Controls.Add(this.dataGridViewEntities);
+            this.Controls.Add(this.splitContainerMain);
             this.Controls.Add(this.toolStripMenu);
             this.Controls.Add(this.footerPanel);
+            this.splitContainerMain.Panel1.Controls.Add(this.grpEntities);
+            this.splitContainerMain.Panel2.Controls.Add(this.grpExcel);
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "MyPluginControl";
-            this.Size = new System.Drawing.Size(553, 396);
+            this.Size = new System.Drawing.Size(553, 500);
             this.Load += new System.EventHandler(this.MyPluginControl_Load);
-            this.Resize += new System.EventHandler(this.MyPluginControl_Resize);
             this.toolStripMenu.ResumeLayout(false);
             this.toolStripMenu.PerformLayout();
+            this.splitContainerMain.Panel1.ResumeLayout(false);
+            this.splitContainerMain.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).EndInit();
+            this.splitContainerMain.ResumeLayout(false);
+            this.grpEntities.ResumeLayout(false);
+            this.grpEntities.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewEntities)).EndInit();
+            this.tableStateStatus.ResumeLayout(false);
+            this.tableStateStatus.PerformLayout();
+            this.grpExcel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewExcel)).EndInit();
+            this.panelExcelPath.ResumeLayout(false);
+            this.panelExcelPath.PerformLayout();
             this.footerPanel.ResumeLayout(false);
             this.footerPanel.PerformLayout();
+            this.footerInfoPanel.ResumeLayout(false);
+            this.footerInfoPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
-
-        private void MyPluginControl_Resize(object sender, EventArgs e)
-        {
-            int width = this.ClientSize.Width;
-            int height = this.ClientSize.Height;
-
-            dataGridViewEntities.Width = (width / 2) - 20;
-            dataGridViewEntities.Height = height - footerPanel.Height - 50;
-
-            dataGridViewExcel.Width = (width / 2) - 20;
-            dataGridViewExcel.Height = height - footerPanel.Height - 50;
-
-            dataGridViewExcel.Left = dataGridViewEntities.Right + 10;
-
-            txtFilePath.Width = dataGridViewExcel.Width;
-            txtFilePath.Top = dataGridViewExcel.Top - 35;
-
-            footerPanel.Top = height - (footerPanel.Height / 2);
-            footerPanel.Width = width - 20;
-
-            // Distribute footer panel controls evenly
-            int footerWidth = footerPanel.Width;
-            int controlWidth = footerWidth / 4;
-        }
-
-        private void dataGridViewEntities_CellContentClick(object sender, DataGridViewCellEventArgs e)
-        {
-            if (e.ColumnIndex == 0) // Assuming the "Select" column is at index 0
-            {
-                foreach (DataGridViewRow row in dataGridViewEntities.Rows)
-                {
-                    if (row.Index != e.RowIndex)
-                    {
-                        DataGridViewCheckBoxCell checkBox = (DataGridViewCheckBoxCell)row.Cells[0];
-                        checkBox.Value = false;
-                    }
-                }
-            }
-        }
-
     }
 }
+

--- a/XrmToolBox.MergeTool/XrmToolBox.MergeTool.csproj
+++ b/XrmToolBox.MergeTool/XrmToolBox.MergeTool.csproj
@@ -56,7 +56,7 @@
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.9.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.49\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.60\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.identitymodel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.7.0.0\lib\net35\microsoft.identitymodel.dll</HintPath>
@@ -71,7 +71,7 @@
       <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.3.0.1\lib\netstandard2.0\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.1.32\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.1.65\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.WebView2.Core, Version=1.0.1343.22, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.WebView2.1.0.1343.22\lib\net45\Microsoft.Web.WebView2.Core.dll</HintPath>
@@ -86,28 +86,46 @@
       <HintPath>..\packages\Microsoft.Web.Xdt.3.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.49\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.60\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.34\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.2.49\lib\net462\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.2.60\lib\net462\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.1.32\lib\net462\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.1.65\lib\net462\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.CrmConnectControl, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.1.32\lib\net462\Microsoft.Xrm.Tooling.CrmConnectControl.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.1.65\lib\net462\Microsoft.Xrm.Tooling.CrmConnectControl.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Ui.Styles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.1.32\lib\net462\Microsoft.Xrm.Tooling.Ui.Styles.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.1.65\lib\net462\Microsoft.Xrm.Tooling.Ui.Styles.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.WebResourceUtility, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.1.32\lib\net462\Microsoft.Xrm.Tooling.WebResourceUtility.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.1.65\lib\net462\Microsoft.Xrm.Tooling.WebResourceUtility.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Common, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Common.5.9.3\lib\net472\NuGet.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Configuration, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Configuration.5.9.3\lib\net472\NuGet.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Frameworks, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Frameworks.5.9.3\lib\net472\NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Packaging.5.9.3\lib\net472\NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Protocol, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Protocol.5.9.3\lib\net472\NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Versioning, Version=5.9.3.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Versioning.5.9.3\lib\net472\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
@@ -129,18 +147,33 @@
     <Reference Include="System.Drawing.Common, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Drawing.Common.8.0.4\lib\net462\System.Drawing.Common.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Pipelines, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Pipelines.9.0.0\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
@@ -170,6 +203,12 @@
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ServiceModel.Http, Version=4.10.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ServiceModel.Http.4.10.3\lib\net461\System.ServiceModel.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceModel.Primitives, Version=4.10.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ServiceModel.Primitives.4.10.3\lib\net461\System.ServiceModel.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encodings.Web, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encodings.Web.9.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
@@ -245,7 +284,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dynamics365.Merge\Dynamics365.Merge.csproj">
@@ -263,6 +301,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="Resources\load_entities.png" />
   </ItemGroup>
   <ItemGroup>

--- a/XrmToolBox.MergeTool/packages.config
+++ b/XrmToolBox.MergeTool/packages.config
@@ -1,44 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DockPanelSuite" version="3.0.6" targetFramework="net471" />
-  <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net471" />
-  <package id="EPPlus" version="7.5.2" targetFramework="net471" />
-  <package id="EPPlus.Interfaces" version="7.5.0" targetFramework="net471" />
-  <package id="EPPlus.System.Drawing" version="7.5.0" targetFramework="net471" />
-  <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net471" />
+  <package id="DockPanelSuite" version="3.0.6" targetFramework="net48" />
+  <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net48" />
+  <package id="EPPlus" version="7.5.2" targetFramework="net48" />
+  <package id="EPPlus.Interfaces" version="7.5.0" targetFramework="net48" />
+  <package id="EPPlus.System.Drawing" version="7.5.0" targetFramework="net48" />
+  <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.0" targetFramework="net48" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.49" targetFramework="net471" />
-  <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.34" targetFramework="net471" />
-  <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.49" targetFramework="net471" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.1.1.32" targetFramework="net471" />
-  <package id="Microsoft.CrmSdk.XrmTooling.WpfControls" version="9.1.1.32" targetFramework="net471" />
-  <package id="Microsoft.IdentityModel" version="7.0.0" targetFramework="net471" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.60" targetFramework="net48" />
+  <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.34" targetFramework="net48" />
+  <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.60" targetFramework="net48" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.1.1.65" targetFramework="net48" />
+  <package id="Microsoft.CrmSdk.XrmTooling.WpfControls" version="9.1.1.65" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel" version="7.0.0" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Abstractions" version="6.35.0" targetFramework="net48" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="5.2.9" targetFramework="net471" />
-  <package id="Microsoft.IO.RecyclableMemoryStream" version="3.0.1" targetFramework="net471" />
-  <package id="Microsoft.Web.WebView2" version="1.0.1343.22" targetFramework="net471" />
-  <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net471" />
-  <package id="MscrmTools.Xrm.Connection" version="1.2023.6.56" targetFramework="net471" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net471" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net471" />
-  <package id="System.ComponentModel.Annotations" version="5.0.0" targetFramework="net471" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="5.2.9" targetFramework="net48" />
+  <package id="Microsoft.IO.RecyclableMemoryStream" version="3.0.1" targetFramework="net48" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.1" targetFramework="net48" />
+  <package id="Microsoft.NETCore.Targets" version="1.1.3" targetFramework="net48" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.24" targetFramework="net48" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1343.22" targetFramework="net48" />
+  <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
+  <package id="MscrmTools.Xrm.Connection" version="1.2023.6.56" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
+  <package id="NuGet.Common" version="5.9.3" targetFramework="net48" />
+  <package id="NuGet.Configuration" version="5.9.3" targetFramework="net48" />
+  <package id="NuGet.Frameworks" version="5.9.3" targetFramework="net48" />
+  <package id="NuGet.Packaging" version="5.9.3" targetFramework="net48" />
+  <package id="NuGet.Protocol" version="5.9.3" targetFramework="net48" />
+  <package id="NuGet.Versioning" version="5.9.3" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.ComponentModel.Annotations" version="5.0.0" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.1" targetFramework="net48" />
-  <package id="System.Drawing.Common" version="8.0.4" targetFramework="net471" />
+  <package id="System.Drawing.Common" version="8.0.4" targetFramework="net48" />
+  <package id="System.IO" version="4.3.0" targetFramework="net48" />
   <package id="System.IO.Pipelines" version="9.0.0" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.5" targetFramework="net471" />
-  <package id="System.Net.Http" version="4.3.4" targetFramework="net471" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net471" />
-  <package id="System.Private.Uri" version="4.3.2" targetFramework="net471" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net471" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net471" />
-  <package id="System.Security.Cryptography.Cng" version="5.0.0" targetFramework="net471" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net471" />
-  <package id="System.Security.Cryptography.Pkcs" version="5.0.1" targetFramework="net471" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net471" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net471" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Private.Uri" version="4.3.2" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Cng" version="5.0.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Pkcs" version="5.0.1" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net48" />
+  <package id="System.ServiceModel.Http" version="4.10.3" targetFramework="net48" />
+  <package id="System.ServiceModel.Primitives" version="4.10.3" targetFramework="net48" />
   <package id="System.Text.Encodings.Web" version="9.0.0" targetFramework="net48" />
   <package id="System.Text.Json" version="9.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="XrmToolBoxPackage" version="1.2023.10.67" targetFramework="net471" />
+  <package id="XrmToolBoxPackage" version="1.2023.10.67" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Features:
- Source record status update: After each merge operation, automatically updates the source record's statecode and statuscode based on user selection from the state/status picklists. Only updates if user has made a selection.

- CRM link navigation: Added clickable links in the validation grid for SourceId and TargetId columns. Clicking on either column opens both source and target records in CRM in separate browser tabs.

- Grid interactivity: Made validation grid selectable and clickable while maintaining read-only state. Users can now select cells and click links without being able to edit the data.

Technical changes:
- Added connectionDetail field to store connection information for URL generation
- Implemented GetCrmBaseUrl() and ExtractBaseUrl() to parse organization service URLs and extract base CRM URL
- Added GetCrmRecordUrl() to generate CRM record URLs in format: {baseUrl}/main.aspx?etn={logicalname}&id={guid}&pagetype=entityrecord
- Updated UpdateConnection() to store ConnectionDetail for later use
- Modified merge process to capture state/status selections before async work (thread-safe) and apply them after each merge
- Added SetupCrmLinks() to configure grid for link navigation
- Implemented OpenBothCrmLinks() to open both source and target records
- Fixed duplicate event handlers that were causing links to open twice
- Updated grid settings: Enabled=true, ReadOnly=true, SelectionMode=CellSelect

Error handling:
- Status update errors are tracked in merge errors list
- Link opening errors show user-friendly messages
- Graceful fallback to settings if connection detail is unavailable